### PR TITLE
refactor(users): refactor password hashing to model level

### DIFF
--- a/server/middleware/auth_middleware.go
+++ b/server/middleware/auth_middleware.go
@@ -5,14 +5,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-
 func AuthMiddleware(c *fiber.Ctx) error {
 	user, err := services.GetUserFromCookiesByJWT(c)
 	if err != nil || user == nil {
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
-	err := services.InsertUserToSession(c, user)
+	err = services.InsertUserToSession(c, user)
 
 	if err != nil {
 		return c.SendStatus(fiber.StatusUnauthorized)

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -21,6 +21,7 @@ type CleanUser struct {
 	FullName string `json:"fullName"`
 }
 
+// BeforeCreate gorm hook that will hash the user's password before creation
 func (u *User) BeforeCreate() (err error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
 

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -22,7 +22,6 @@ type CleanUser struct {
 }
 
 func (u *User) BeforeCreate() (err error) {
-
 	hash, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
 
 	if err != nil {

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"errors"
+	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
@@ -9,7 +11,7 @@ type User struct {
 	Email       string `json:"email"`
 	Password    string `json:"password"`
 	FullName    string `json:"fullName" gorm:"column:full_name"`
-	IsSuperuser bool   `json:"isSuperuser" gorm:""column:is_superuser;default:false"`
+	IsSuperuser bool   `json:"isSuperuser" gorm:"column:is_superuser;default:false"`
 
 	Communities []*Community `gorm:"many2many:communities_users"`
 }
@@ -17,6 +19,19 @@ type User struct {
 type CleanUser struct {
 	Email    string `json:"email"`
 	FullName string `json:"fullName"`
+}
+
+func (u *User) BeforeCreate() (err error) {
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
+
+	if err != nil {
+		return errors.New("password hashing failed")
+	}
+
+	u.Password = string(hash)
+
+	return
 }
 
 func (u User) Clean() CleanUser {

--- a/server/services/users_service.go
+++ b/server/services/users_service.go
@@ -1,11 +1,9 @@
 package services
 
 import (
-	"errors"
 	"github.com/bokoness/lashon/database"
 	"github.com/bokoness/lashon/models"
 	"github.com/gofiber/fiber/v2/log"
-	"golang.org/x/crypto/bcrypt"
 )
 
 func GetUser(uid uint) (*models.User, error) {
@@ -31,15 +29,6 @@ func GetUserByEmail(email string) (*models.User, error) {
 }
 
 func CreateUser(data models.User) (*models.User, error) {
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(data.Password), bcrypt.DefaultCost)
-
-	if err != nil {
-		return nil, errors.New("password hashing failed")
-	}
-
-	data.Password = string(hash)
-
 	if err := database.DB.Create(&data).Error; err != nil {
 		log.Error(err)
 		return nil, err


### PR DESCRIPTION
Password hashing logic has been moved from the CreateUser function in the users_service.go file to the User model (user.go). It now happens automatically before creating a new user in the database. This change adheres to better software design principles by centralizing the encryption logic within the model itself, ensuring code reusability and maintainability. In the auth_middleware.go, the redundant error declaration was also removed to fix the scope issue.

[Link to Github Issue](https://github.com/Bokoness/kehilason/issues/24)

